### PR TITLE
CI: set up some initial CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: build
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  windows:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        include:
+          - branch: swift-5.4.2-release
+            tag: 5.4.2-RELEASE
+
+          - branch: swift-5.5-branch
+            tag: 5.5-DEVELOPMENT-SNAPSHOT-2021-07-19-a
+
+          - branch: development
+            tag: DEVELOPMENT-SNAPSHOT-2021-07-15-a
+
+    steps:
+      - name: Install Swift ${{ matrix.tag }}
+        run: |
+          function Update-EnvironmentVariables {
+            foreach ($level in "Machine", "User") {
+              [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
+                # For Path variables, append the new values, if they're not already in there
+                if ($_.Name -Match 'Path$') {
+                  $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
+                }
+                $_
+              } | Set-Content -Path { "Env:$($_.Name)" }
+            }
+          }
+          Install-Binary -Url "https://swift.org/builds/${{ matrix.branch }}/windows10/swift-${{ matrix.tag }}/swift-${{ matrix.tag }}-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+          Update-EnvironmentVariables
+          # Reset Path and environment
+          echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+          Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
+
+      - uses: actions/checkout@v2
+      - name: Build
+        run: swift build
+      - name: Test
+        run: swift test


### PR DESCRIPTION
Add initial CI jobs for testing before merging.  This currently only
adds Windows jobs as I don't know how to setup the version matrix on
the other platforms.  Future work could add Linux and macOS tests to
the matrix.  Add coverage for 5.4+ as the 5.3 release didn't include
SPM on Windows.