### PR TITLE
Cassowary: deprecate the use of `|` for strength

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ strengths.  Three standard strengths are defined by default:
 We can add a constraint to our previous example to place x<sub>m</sub> at 50 by
 adding a new `weak` constraint:
 
-```Swift
-simplex.add(constraint: (x_m == 50.0) | Strength.weak)
+```swift
+simplex.add(constraint: x_m == 50.0, strength: .weak)
 ```
 
 ### Edit Variables

--- a/Sources/Cassowary/Solver.swift
+++ b/Sources/Cassowary/Solver.swift
@@ -444,8 +444,13 @@ public class Solver {
     try optimize(objective: objective)
   }
 
+  @available(*, deprecated, message: "renamed add(constraint:strength:)")
   public func add(constraint: Constraint, _ strength: Strength) throws {
-    try add(constraint: constraint | strength)
+    try add(constraint: constraint, strength: strength)
+  }
+
+  public func add(constraint: Constraint, strength: Strength) throws {
+    try add(constraint: Constraint(constraint, strength))
   }
 
   /// Remove a constraint from the solver

--- a/Sources/Cassowary/Symbolics.swift
+++ b/Sources/Cassowary/Symbolics.swift
@@ -376,10 +376,12 @@ public func >= (_ lhs: Double, _ rhs: Variable) -> Constraint {
 
 // MARK - constraint strength modifiers
 
+@available(*, deprecated, message: "explicitly pass strength when adding the constraint")
 public func | (_ lhs: Constraint, _ rhs: Strength) -> Constraint {
   return Constraint(lhs, rhs)
 }
 
+@available(*, deprecated, message: "explicitly pass strength when adding the constraint")
 public func | (_ lhs: Strength, _ rhs: Constraint) -> Constraint {
   return Constraint(rhs, lhs)
 }

--- a/Tests/CassowaryTests/CassowaryTests.swift
+++ b/Tests/CassowaryTests/CassowaryTests.swift
@@ -40,8 +40,8 @@ final class CassowaryTests: XCTestCase {
 
     try solver.add(constraint: x <= y)
     try solver.add(constraint: y == x + 3.0)
-    try solver.add(constraint: x == 10.0, .weak)
-    try solver.add(constraint: y == 10.0, .weak)
+    try solver.add(constraint: x == 10.0, strength: .weak)
+    try solver.add(constraint: y == 10.0, strength: .weak)
 
     solver.update()
 
@@ -59,7 +59,7 @@ final class CassowaryTests: XCTestCase {
 
     let x: Variable = Variable("x")
 
-    try solver.add(constraint: x <= 100.0, .weak)
+    try solver.add(constraint: x <= 100.0, strength: .weak)
 
     solver.update()
 
@@ -94,8 +94,8 @@ final class CassowaryTests: XCTestCase {
     let x: Variable = Variable("x")
     let y: Variable = Variable("y")
 
-    try solver.add(constraint: x == 100, .weak)
-    try solver.add(constraint: y == 120, .strong)
+    try solver.add(constraint: x == 100, strength: .weak)
+    try solver.add(constraint: y == 120, strength: .strong)
 
     let c10: Constraint = x <= 10.0
     let c20: Constraint = x <= 20.0
@@ -162,7 +162,7 @@ final class CassowaryTests: XCTestCase {
 
     try solver.add(constraint: v + w == 0.0)
     try solver.add(constraint: v == 10.0)
-    try solver.add(constraint: w >= 0.0, .weak)
+    try solver.add(constraint: w >= 0.0, strength: .weak)
 
     solver.update()
 
@@ -177,8 +177,8 @@ final class CassowaryTests: XCTestCase {
     let w: Variable = Variable("w")
 
     try solver.add(constraint: v + w == 0.0)
-    try solver.add(constraint: v >= 10.0, .medium)
-    try solver.add(constraint: w == 2.0, .strong)
+    try solver.add(constraint: v >= 10.0, strength: .medium)
+    try solver.add(constraint: w == 2.0, strength: .strong)
 
     solver.update()
 


### PR DESCRIPTION
Instead of using the `|` on the constraint to add the strength on the
constraint, change the `Solver` to make the strength parameter a labelled
parameter.  There were previously three different ways to add a constraint with
a strength:

1. `solver.add(constraint:_:)`
2. `solver.add(constraint: Constraint(_:strength:))` or `solver.add(constraint: Constraint(_:_:_:))`
3. `solver.add(constraint:)`, `|` on the constraint to compose the strength

This effectively removes `solver.add(constraint:_:)` in favour of
`solver.add(constraint:strength:)` and retains option 2.  This way, the strength
can be specified when adding the constraint to the solver or when creating the
constraint.