### PR TITLE
Cassowary: clean up whitespace (NFC)

### DIFF
--- a/Sources/Cassowary/Constraint.swift
+++ b/Sources/Cassowary/Constraint.swift
@@ -28,7 +28,7 @@ public class Constraint {
   }
 }
 
-extension Constraint : Hashable {
+extension Constraint: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(expression)
     hasher.combine(operation)
@@ -36,7 +36,7 @@ extension Constraint : Hashable {
   }
 }
 
-extension Constraint : Equatable {
+extension Constraint: Equatable {
   public static func == (lhs: Constraint, rhs: Constraint) -> Bool {
     return lhs.expression == rhs.expression &&
            lhs.operation == rhs.operation &&
@@ -44,7 +44,7 @@ extension Constraint : Equatable {
   }
 }
 
-extension Constraint : CustomStringConvertible {
+extension Constraint: CustomStringConvertible {
   public var description: String {
     var value: String = expression.terms.reduce("") {
       $0 + "\($1.coefficient) * \($1.variable.name) + "
@@ -59,4 +59,3 @@ extension Constraint : CustomStringConvertible {
     return value
   }
 }
-

--- a/Sources/Cassowary/Errors.swift
+++ b/Sources/Cassowary/Errors.swift
@@ -1,61 +1,59 @@
 // Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>.
 // SPDX-License-Identifier: BSD-3-Clause
 
-public struct UnsatisfiableConstraint : Error {
+public struct UnsatisfiableConstraint: Error {
   private let constraint: Constraint
   public init(_ constraint: Constraint) {
     self.constraint = constraint
   }
 }
 
-extension UnsatisfiableConstraint : CustomStringConvertible {
+extension UnsatisfiableConstraint: CustomStringConvertible {
   public var description: String {
     return "unable to satisfy constraint: \(constraint)"
   }
 }
 
-public struct UnknownConstraint : Error {
+public struct UnknownConstraint: Error {
   private let constraint: Constraint
   public init(_ constraint: Constraint) {
     self.constraint = constraint
   }
 }
 
-extension UnknownConstraint : CustomStringConvertible {
+extension UnknownConstraint: CustomStringConvertible {
   public var description: String {
     return "unknown constraint: \(constraint)"
   }
 }
 
-public struct DuplicateConstraint : Error {
+public struct DuplicateConstraint: Error {
   private let constraint: Constraint
   public init(_ constraint: Constraint) {
     self.constraint = constraint
   }
 }
 
-extension DuplicateConstraint : CustomStringConvertible {
+extension DuplicateConstraint: CustomStringConvertible {
   public var description: String {
     return "duplicate constraint: \(constraint)"
   }
 }
 
-public struct UnknownEditVariable : Error {
+public struct UnknownEditVariable: Error {
   public init(_ variable: Variable) {
   }
 }
 
-public struct DuplicateEditVariable : Error {
+public struct DuplicateEditVariable: Error {
   public init(_ variable: Variable) {
   }
 }
 
-public struct BadRequiredStrength : Error {
+public struct BadRequiredStrength: Error {
 }
 
-internal struct InternalSolverError : Error {
+internal struct InternalSolverError: Error {
   public init(_ message: String) {
   }
 }
-
-

--- a/Sources/Cassowary/Expression.swift
+++ b/Sources/Cassowary/Expression.swift
@@ -24,14 +24,14 @@ public struct Expression {
   }
 }
 
-extension Expression : Hashable {
+extension Expression: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(terms)
     hasher.combine(constant)
   }
 }
 
-extension Expression : Equatable {
+extension Expression: Equatable {
   public static func == (lhs: Expression, rhs: Expression) -> Bool {
     return lhs.terms == rhs.terms && lhs.constant == rhs.constant
   }
@@ -44,4 +44,3 @@ internal func reduce(_ expression: Expression) -> Expression {
   }
   return Expression(vars.map { Term($0, $1) }, expression.constant)
 }
-

--- a/Sources/Cassowary/Solver.swift
+++ b/Sources/Cassowary/Solver.swift
@@ -576,7 +576,7 @@ public class Solver {
   }
 }
 
-extension Solver : CustomStringConvertible {
+extension Solver: CustomStringConvertible {
   public var description: String {
     return """
 Objective
@@ -607,4 +607,3 @@ Constraints
     }
   }
 }
-

--- a/Sources/Cassowary/Symbol.swift
+++ b/Sources/Cassowary/Symbol.swift
@@ -27,7 +27,7 @@ extension Symbol {
   static let invalid: Symbol = Symbol(.invalid, 0)
 }
 
-extension Symbol : Comparable {
+extension Symbol: Comparable {
   public static func == (lhs: Symbol, rhs: Symbol) -> Bool {
     return lhs.id == rhs.id
   }
@@ -37,13 +37,13 @@ extension Symbol : Comparable {
   }
 }
 
-extension Symbol : Hashable {
+extension Symbol: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(id)
     hasher.combine(type)
   }
 }
-extension Symbol : CustomStringConvertible {
+extension Symbol: CustomStringConvertible {
   public var description: String {
     switch type {
     case .invalid: return "i\(id)"
@@ -54,4 +54,3 @@ extension Symbol : CustomStringConvertible {
     }
   }
 }
-

--- a/Sources/Cassowary/Term.swift
+++ b/Sources/Cassowary/Term.swift
@@ -15,16 +15,15 @@ public class Term {
   }
 }
 
-extension Term : Hashable {
+extension Term: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(variable)
     hasher.combine(coefficient)
   }
 }
 
-extension Term : Equatable {
+extension Term: Equatable {
   public static func == (lhs: Term, rhs: Term) -> Bool {
     return lhs.variable == rhs.variable && lhs.coefficient == rhs.coefficient
   }
 }
-

--- a/Sources/Cassowary/Variable.swift
+++ b/Sources/Cassowary/Variable.swift
@@ -11,15 +11,14 @@ public class Variable {
   }
 }
 
-extension Variable : Hashable {
+extension Variable: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(name)
   }
 }
 
-extension Variable : Equatable {
+extension Variable: Equatable {
   public static func == (lhs: Variable, rhs: Variable) -> Bool {
     return lhs.name == rhs.name && lhs.value == rhs.value
   }
 }
-


### PR DESCRIPTION
This cleans up the code formatting, removing some extraneous whitespace
throughout the codebase.