### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: windows-latest
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - branch: swift-5.4.3-release


### PR DESCRIPTION
Disable fail fast as we have a growing matrix for the test and a failure in one does not necessarily imply a failure in the other build configurations.