### PR TITLE
Fix for intermittent failure for multi term expressions.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,14 @@ let cassowary = Package(
   products: [
     .library(name: "cassowary", type: .dynamic, targets: ["Cassowary"]),
   ],
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-collections.git",
+             .upToNextMinor(from: "1.0.0")),
+  ],
   targets: [
-    .target(name: "Cassowary", dependencies: []),
+    .target(name: "Cassowary", dependencies: [
+        .product(name: "OrderedCollections", package: "swift-collections")
+    ]),
     .testTarget(name: "CassowaryTests", dependencies: ["Cassowary"]),
   ]
 )

--- a/Sources/Cassowary/Expression.swift
+++ b/Sources/Cassowary/Expression.swift
@@ -1,6 +1,9 @@
 // Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>.
 // SPDX-License-Identifier: BSD-3-Clause
 
+@_implementationOnly
+import OrderedCollections
+
 public struct Expression {
   public let terms: [Term]
   public let constant: Double
@@ -38,7 +41,7 @@ extension Expression: Equatable {
 }
 
 internal func reduce(_ expression: Expression) -> Expression {
-  var vars: [Variable:Double] = [:]
+  var vars: OrderedDictionary<Variable, Double> = [:]
   for term in expression.terms {
     vars[term.variable] = vars[term.variable, default: 0.0] + term.coefficient
   }

--- a/Sources/Cassowary/Row.swift
+++ b/Sources/Cassowary/Row.swift
@@ -1,8 +1,12 @@
 // Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>.
 // SPDX-License-Identifier: BSD-3-Clause
 
+@_implementationOnly
+import OrderedCollections
+
 internal class Row {
-  public private(set) var cells: [Symbol:Double] = [:]
+  // Must be in insertion order
+  public private(set) var cells: OrderedDictionary<Symbol, Double> = [:]
   public private(set) var constant: Double
 
   public init() {

--- a/Tests/CassowaryTests/CassowaryTests.swift
+++ b/Tests/CassowaryTests/CassowaryTests.swift
@@ -218,4 +218,25 @@ final class CassowaryTests: XCTestCase {
     XCTAssertEqual(x_l.value, 80)
     XCTAssertEqual(x_r.value, 100)
   }
+
+  // Terms must be evaluated in insertion order
+  func testMultiTermExpressionOrder() throws {
+    let solver: Solver = Solver()
+
+    let c: Variable = Variable("c")
+    let a: Variable = Variable("a")
+    let b: Variable = Variable("b")
+
+    try solver.add(variable: c, strength: .strong)
+    try solver.add(constraint: a >= 0, .strong)
+    try solver.add(constraint: b >= a, .strong)
+    try solver.add(constraint: b - a == c, .required)
+    try solver.suggest(value: 100, for: c)
+
+    solver.update()
+
+    XCTAssertEqual(a.value, 0)
+    XCTAssertEqual(b.value, 100)
+    XCTAssertEqual(c.value, 100)
+  }
 }


### PR DESCRIPTION
Following test will fail intermittently:

    let solver: Solver = Solver()

    let c: Variable = Variable("c")
    let a: Variable = Variable("a")
    let b: Variable = Variable("b")

    try solver.add(variable: c, strength: .strong)
    try solver.add(constraint: a >= 0, .strong)
    try solver.add(constraint: b >= a, .strong)
    try solver.add(constraint: b - a == c, .required)
    try solver.suggest(value: 100, for: c)

    solver.update()

    XCTAssertEqual(a.value, 0)
    XCTAssertEqual(b.value, 100)
    XCTAssertEqual(c.value, 100)

The evaluation order of the cells in the "Row" is not  in insertion order but in dictionary order. The issue is also with reduce() in Expression which also changes the evaluation order. The original kiwi code stores all key pairs in a std::vector so all pairs are in insertion order. It's possible that dictionaries in Solver.swift should be Ordered as well (they are in kiwi). 
