### PR TITLE
GHA: simplify the build rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,15 @@ jobs:
         include:
           - branch: swift-5.4.3-release
             tag: 5.4.3-RELEASE
-            options: '-Xmanifest -use-ld=link -Xswiftc -use-ld=link'
+            options: ''
 
           - branch: swift-5.5.3-release
             tag: 5.5.3-RELEASE
-            options: '-Xmanifest -use-ld=link -Xswiftc -use-ld=link'
+            options: ''
 
           - branch: development
             tag: DEVELOPMENT-SNAPSHOT-2021-07-24-a
-            options: '-Xmanifest -use-ld=link -Xswiftc -use-ld=link'
+            options: ''
 
     steps:
       - uses: compnerd/gha-setup-swift@main


### PR DESCRIPTION
Revert to the default behaviour of the toolchain distribution (using lld).  There is no advantage to the explicit use of link (compatibility is validated by the toolchain builds using link).