### PR TITLE
GHA: upgrade the checkout action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           tag: ${{ matrix.tag }}
           branch: ${{ matrix.branch }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build
         run: swift build ${{ matrix.options }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
           tag: ${{ matrix.tag }}
           branch: ${{ matrix.branch }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build
         run: swift build ${{ matrix.options }}


### PR DESCRIPTION
Upgrade to v3 series of checkout to avoid the deprecation warnings.