### PR TITLE
Cassowary: finalise classes

### DIFF
--- a/Sources/Cassowary/Constraint.swift
+++ b/Sources/Cassowary/Constraint.swift
@@ -10,7 +10,7 @@ public extension Constraint {
 }
 
 /// Describes a constraint over variables in the system.
-public class Constraint {
+public final class Constraint {
   /// The expression that is constrained.
   public let expression: Expression
 

--- a/Sources/Cassowary/Row.swift
+++ b/Sources/Cassowary/Row.swift
@@ -4,7 +4,7 @@
 @_implementationOnly
 import OrderedCollections
 
-internal class Row {
+internal final class Row {
   // Must be in insertion order
   public private(set) var cells: OrderedDictionary<Symbol, Double> = [:]
   public private(set) var constant: Double

--- a/Sources/Cassowary/Solver.swift
+++ b/Sources/Cassowary/Solver.swift
@@ -3,7 +3,7 @@
 
 private typealias Tag = (marker: Symbol, other: Symbol)
 
-private class EditInfo {
+private final class EditInfo {
   public var tag: Tag
   public var constraint: Constraint
   public var constant: Double
@@ -15,7 +15,7 @@ private class EditInfo {
   }
 }
 
-public class Solver {
+public final class Solver {
   private var rows: [Symbol:Row] = [:]
   private var constraints: [Constraint:Tag] = [:]
   private var variables: [Variable:Symbol] = [:]

--- a/Sources/Cassowary/Term.swift
+++ b/Sources/Cassowary/Term.swift
@@ -1,7 +1,7 @@
 // Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>.
 // SPDX-License-Identifier: BSD-3-Clause
 
-public class Term {
+public final class Term {
   public let variable: Variable
   public let coefficient: Double
 

--- a/Sources/Cassowary/Variable.swift
+++ b/Sources/Cassowary/Variable.swift
@@ -1,7 +1,7 @@
 // Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>.
 // SPDX-License-Identifier: BSD-3-Clause
 
-public class Variable {
+public final class Variable {
   public var name: String
   public var value: Double
 


### PR DESCRIPTION
The class types are used for reference semantics and are not intended to be extended.  Mark them as `final` to indicate that.