### PR TITLE
GHA: remove `gha-setup-vsdevenv`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,6 @@ jobs:
             options: ''
 
     steps:
-      - uses: seanmiddleditch/gha-setup-vsdevenv@master
       - uses: compnerd/gha-setup-swift@main
         with:
           tag: ${{ matrix.tag }}


### PR DESCRIPTION
The `gha-setup-swift` provides a sufficiently properly configured environment that we should be able to simply use `swift build` and `swift test`.