### PR TITLE
gitignore: ignore the default SPM build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 # git ls-files --others --exclude-from=.git/info/exclude
 # Lines that start with '#' are comments.
-# For a project mostly in C, the following would be a good set of
-# exclude patterns (uncomment them if you want to use them):
-# *.[oa]
-# *~
 
-.*.sw[nop]
+.*.sw?
+.build/


### PR DESCRIPTION
Update the gitignore to ignore more swap files by generalising the pattern and add the default SPM directory.