### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
-          components: Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64
+          components: Microsoft.VisualStudio.Component.VC.14.42.17.12.x86.x64
           toolset_version: 14.42
           winsdk: 10.0.22621.0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: swift build -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} ${{ matrix.options }}
+        run: swift build --build-tests -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} ${{ matrix.options }}
 
       - name: Test
-        run: swift test -Xbuild-tools-swiftc -Xfrontend -Xbuild-tools-swiftc -dump-clang-diagnostics -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} -Xswiftc -windows-sdk-root -Xswiftc "${env:WindowsSdkDir}" -Xswiftc -windows-sdk-version -Xswiftc ${env:UCRTVersion} ${{ matrix.options }}
+        run: swift test ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,7 @@ jobs:
     steps:
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
-          components: Microsoft.VisualStudio.Component.VC.14.42.17.12.x86.x64
-          toolset_version: 14.42
+          toolset_version: 14.29
           winsdk: 10.0.22621.0
 
       - uses: compnerd/gha-setup-swift@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - branch: development
             tag: DEVELOPMENT-SNAPSHOT-2025-01-31-a
-            options: ''
+            options: '-Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion}'
 
     steps:
       - uses: compnerd/gha-setup-vsdevenv@main
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: swift build ${{ matrix.options }} -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc $env:UCRTVersion -Xbuild-tools-swiftc -Xfrontend -Xbuild-tools-swiftc -dump-clang-diagnostics
+        run: swift build ${{ matrix.options }}
 
       - name: Test
         run: swift test ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,4 +35,4 @@ jobs:
         run: swift build -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} ${{ matrix.options }}
 
       - name: Test
-        run: swift test -Xbuild-tools-swiftc -frontend -Xbuild-tools-swiftc -dump-clang-diagnostics -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} ${{ matrix.options }}
+        run: swift test -Xbuild-tools-swiftc -Xfrontend -Xbuild-tools-swiftc -dump-clang-diagnostics -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           components: Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64
           toolset_version: 14.29
+          winsdk: 10.0.22621.0
 
       - uses: compnerd/gha-setup-swift@main
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,4 +35,4 @@ jobs:
         run: swift build -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} ${{ matrix.options }}
 
       - name: Test
-        run: swift test -Xbuild-tools-swiftc -Xfrontend -Xbuild-tools-swiftc -dump-clang-diagnostics -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} ${{ matrix.options }}
+        run: swift test -Xbuild-tools-swiftc -Xfrontend -Xbuild-tools-swiftc -dump-clang-diagnostics -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} -Xswiftc -windows-sdk-root -Xswiftc "${env:WindowsSdkDir}" -Xswiftc -windows-sdk-version -Xswiftc ${env:UCRTVersion} ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,4 +35,4 @@ jobs:
         run: swift build -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} ${{ matrix.options }}
 
       - name: Test
-        run: swift test -Xswiftc -frontend -Xswiftc -dump-clang-diagnostics -Xswiftc -windows-sdk-root -Xswiftc "${env:WindowsSdkDir}" -Xswiftc -windows-sdk-version -Xswiftc ${env:UCRTVersion} ${{ matrix.options }}
+        run: swift test -Xbuild-tools-swiftc -frontend -Xbuild-tools-swiftc -dump-clang-diagnostics -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,11 @@ jobs:
             options: ''
 
     steps:
+      - uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          components: Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64
+          toolset_version: 14.29
+
       - uses: compnerd/gha-setup-swift@main
         with:
           tag: ${{ matrix.tag }}
@@ -35,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: swift build ${{ matrix.options }}
+        run: swift build ${{ matrix.options }} -Xswiftc -visualc-tools-version -Xswiftc 14.29 -Xswiftc -windows-sdk-version -Xswiftc 10.0.22621.0 -Xbuild-tools-swiftc -visualc-tools-version -Xbuild-tools-swiftc 14.29 -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc 10.0.22621.0
 
       - name: Test
-        run: swift test ${{ matrix.options }}
+        run: swift test ${{ matrix.options }} -Xswiftc -visualc-tools-version -Xswiftc 14.29 -Xswiftc -windows-sdk-version -Xswiftc 10.0.22621.0 -Xbuild-tools-swiftc -visualc-tools-version -Xbuild-tools-swiftc 14.29 -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc 10.0.22621.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,4 +35,4 @@ jobs:
         run: swift build -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} ${{ matrix.options }}
 
       - name: Test
-        run: swift test -Xswiftc -windows-sdk-root -Xswiftc "${env:WindowsSdkDir}" -Xswiftc -windows-sdk-version -Xswiftc ${env:UCRTVersion} ${{ matrix.options }}
+        run: swift test -Xswiftc -frontend -Xswiftc -dump-clang-diagnostics -Xswiftc -windows-sdk-root -Xswiftc "${env:WindowsSdkDir}" -Xswiftc -windows-sdk-version -Xswiftc ${env:UCRTVersion} ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: swift build ${{ matrix.options }} -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc $env:UCRTVersion -Xbuild-tools-swiftc -Xfrontend -Xbuild-tools-swiftc -dump-clang-diagnostics
+        run: swift build ${{ matrix.options }} -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc $env:UCRTVersion -Xbuild-tools-swiftc -Xfrontend -Xbuild-tools-swiftc -dump-clang-diagnostics
 
       - name: Test
         run: swift test ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,16 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - branch: swift-5.4.3-release
-            tag: 5.4.3-RELEASE
-            options: '-Xmanifest -use-ld=link -Xswiftc -use-ld=link'
-
-          - branch: swift-5.5.3-release
-            tag: 5.5.3-RELEASE
-            options: '-Xmanifest -use-ld=link -Xswiftc -use-ld=link'
-
           - branch: development
-            tag: DEVELOPMENT-SNAPSHOT-2023-08-12-a
+            tag: DEVELOPMENT-SNAPSHOT-2025-02-27-a
             options: ''
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - branch: development
-            tag: DEVELOPMENT-SNAPSHOT-2025-02-27-a
+            tag: DEVELOPMENT-SNAPSHOT-2025-02-24-a
             options: ''
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: swift build ${{ matrix.options }} -Xswiftc -visualc-tools-version -Xswiftc 14.29 -Xswiftc -windows-sdk-version -Xswiftc 10.0.22621.0 -Xbuild-tools-swiftc -visualc-tools-version -Xbuild-tools-swiftc 14.29 -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc 10.0.22621.0
+        run: swift build ${{ matrix.options }}
 
       - name: Test
-        run: swift test ${{ matrix.options }} -Xswiftc -visualc-tools-version -Xswiftc 14.29 -Xswiftc -windows-sdk-version -Xswiftc 10.0.22621.0 -Xbuild-tools-swiftc -visualc-tools-version -Xbuild-tools-swiftc 14.29 -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc 10.0.22621.0
+        run: swift test ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: swift build ${{ matrix.options }} -Xbuild-tools-swiftc -Xcc -Xbuild-tools-swiftc -v
+        run: swift build ${{ matrix.options }} -Xbuild-tools-swiftc -Xfrontend -Xbuild-tools-swiftc -dump-clang-diagnostics
 
       - name: Test
         run: swift test ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - branch: development
             tag: DEVELOPMENT-SNAPSHOT-2025-01-31-a
-            options: '-Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion}'
+            options: ''
 
     steps:
       - uses: compnerd/gha-setup-vsdevenv@main
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: swift build ${{ matrix.options }}
+        run: swift build -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} ${{ matrix.options }}
 
       - name: Test
-        run: swift test ${{ matrix.options }}
+        run: swift test -Xswiftc -windows-sdk-root -Xswiftc "${env:WindowsSdkDir}" -Xswiftc -windows-sdk-version -Xswiftc ${env:UCRTVersion} ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
           components: Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64
-          toolset_version: 14.29
+          toolset_version: 14.42
           winsdk: 10.0.22621.0
 
       - uses: compnerd/gha-setup-swift@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: swift build --build-tests -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} ${{ matrix.options }}
+        run: swift build --build-tests -Xbuild-tools-swiftc -windows-sdk-root -Xbuild-tools-swiftc "${env:WindowsSdkDir}" -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc ${env:UCRTVersion} -Xswiftc -windows-sdk-root -Xswiftc "${env:WindowsSdkDir}" -Xswiftc -windows-sdk-version -Xswiftc ${env:UCRTVersion} ${{ matrix.options }}
 
       - name: Test
         run: swift test ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - branch: development
-            tag: DEVELOPMENT-SNAPSHOT-2025-02-24-a
+            tag: DEVELOPMENT-SNAPSHOT-2025-01-31-a
             options: ''
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: swift build ${{ matrix.options }} -Xbuild-tools-swiftc -Xfrontend -Xbuild-tools-swiftc -dump-clang-diagnostics
+        run: swift build ${{ matrix.options }} -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc $env:UCRTVersion -Xbuild-tools-swiftc -Xfrontend -Xbuild-tools-swiftc -dump-clang-diagnostics
 
       - name: Test
         run: swift test ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: swift build ${{ matrix.options }}
+        run: swift build ${{ matrix.options }} -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc 10.0.22621.0
 
       - name: Test
         run: swift test ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: swift build ${{ matrix.options }} -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc 10.0.22621.0
+        run: swift build ${{ matrix.options }} -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc 10.0.22621.0 -Xbuild-tools-swiftc -visualc-tools-version -Xbuild-tools-swiftc 14.29
 
       - name: Test
         run: swift test ${{ matrix.options }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: swift build ${{ matrix.options }} -Xbuild-tools-swiftc -windows-sdk-version -Xbuild-tools-swiftc 10.0.22621.0 -Xbuild-tools-swiftc -visualc-tools-version -Xbuild-tools-swiftc 14.29
+        run: swift build ${{ matrix.options }} -Xbuild-tools-swiftc -Xcc -Xbuild-tools-swiftc -v
 
       - name: Test
         run: swift test ${{ matrix.options }}


### PR DESCRIPTION
Pin VS ToolSet to 14.29.x as the newer VC Tools need to re-modularise the SDK. Similarly, pin the Windows SDK to 10.0.22621.0 to ensure that we are able to use the SDK modularization.